### PR TITLE
Styled applet previews

### DIFF
--- a/src/components/AppletPreview.js
+++ b/src/components/AppletPreview.js
@@ -1,15 +1,83 @@
 import React, { Component } from 'react';
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { Card } from 'react-native-elements';
 
 export default class AppletPreview extends Component {
+  componentWillMount() {
+    styles.preview.backgroundColor = this.props.data.color;
+  };
 
   render() {
     return (
-      <Card title={this.props.data.title} >
-        <Text>Ping me when</Text>
-        <Text>{this.props.data.organization}</Text>
-      </Card>
+      <View style={styles.preview}>
+        <View style={styles.body}>
+          <Text style={styles.pingMeWhen}>Ping me when</Text>
+          <View style={styles.divider} />
+          <Text style={styles.titleText}>{this.props.data.title}</Text>
+        </View>
+        <View style={styles.footer}>
+          <Text style={styles.status}>{this.props.data.status}</Text>
+          <Text style={styles.lastActive}>{this.props.data.lastActive}</Text>
+        </View>
+      </View>
     );
   }
 }
+
+let styles = StyleSheet.create({
+  preview: {
+    backgroundColor: "steelblue",
+    borderRadius: 10,
+    marginLeft: 10,
+    marginRight: 10,
+    marginTop: 20,
+    flexDirection: "column",
+    minHeight: 190,
+  },
+  body: {
+    padding: 20,
+  },
+  pingMeWhen: {
+    marginTop: 10,
+    color: "#FFF",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  divider: {
+    marginTop: 7,
+    height: 2,
+    width: 35,
+    backgroundColor: "#FFF"
+  },
+  titleText: {
+    marginTop: 12,
+    color: "#FFF",
+    fontSize: 24,
+    fontWeight: "700",
+  },
+  footer: {
+    zIndex: 1, // Above rest of preview
+    height: 30,
+    width: "100%",
+    borderBottomLeftRadius: 10,
+    borderBottomRightRadius: 10,
+    backgroundColor: 'rgba(0,0,0,0.3)', // Black with opacity of 40%
+    position: "absolute",
+    bottom: 0,
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingTop: 5,
+    paddingBottom: 5,
+    paddingLeft: 20,
+    paddingRight: 20,
+  },
+  status: {
+    color: "#999",
+    fontWeight: "700",
+  },
+  lastActive: {
+    color: "#999",
+    fontWeight: "700",
+  },
+});

--- a/src/components/AppletPreview.js
+++ b/src/components/AppletPreview.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Card } from 'react-native-elements';
 
 export default class AppletPreview extends Component {
   componentWillMount() {

--- a/src/components/AppletPreview.js
+++ b/src/components/AppletPreview.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+import { Text, View } from 'react-native';
+import { Card } from 'react-native-elements';
+
+export default class AppletPreview extends Component {
+
+  render() {
+    return (
+      <Card title={this.props.data.title} >
+        <Text>Ping me when</Text>
+        <Text>{this.props.data.organization}</Text>
+      </Card>
+    );
+  }
+}

--- a/src/components/AppletsFeed.js
+++ b/src/components/AppletsFeed.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import {
   Text,
   View,
-  ScrollView
+  ScrollView,
+  StyleSheet
 } from 'react-native';
 import { List, ListItem } from 'react-native-elements';
 
@@ -12,7 +13,7 @@ export default class AppletsFeed extends Component {
 
   render() {
     return (
-      <ScrollView>
+      <ScrollView style={styles.container}>
         {this.props.feeds.map((feed) => (
           <AppletPreview key={feed.id} data={feed} />
         ))}
@@ -21,14 +22,9 @@ export default class AppletsFeed extends Component {
   }
 }
 
-//
-// <List>
-//   {this.props.feeds.map((feed) => (
-//     <ListItem
-//       key={feed.id}
-//       title={feed.title}
-//       subtitle={feed.lastActive}
-//       hideChevron
-//     />
-//   ))}
-// </List>
+let styles = StyleSheet.create({
+  container: {
+    // marginBottom: 70,
+    // paddingBottom: 50,
+  },
+});

--- a/src/components/AppletsFeed.js
+++ b/src/components/AppletsFeed.js
@@ -6,24 +6,29 @@ import {
 } from 'react-native';
 import { List, ListItem } from 'react-native-elements';
 
-class Feed extends Component {
+import AppletPreview from './AppletPreview';
+
+export default class AppletsFeed extends Component {
 
   render() {
     return (
       <ScrollView>
-        <List>
-          {this.props.feeds.map((feed) => (
-            <ListItem
-              key={feed.id}
-              title={feed.title}
-              subtitle={feed.lastActive}
-              hideChevron
-            />
-          ))}
-        </List>
+        {this.props.feeds.map((feed) => (
+          <AppletPreview key={feed.id} data={feed} />
+        ))}
       </ScrollView>
     );
   }
 }
 
-export default Feed;
+//
+// <List>
+//   {this.props.feeds.map((feed) => (
+//     <ListItem
+//       key={feed.id}
+//       title={feed.title}
+//       subtitle={feed.lastActive}
+//       hideChevron
+//     />
+//   ))}
+// </List>

--- a/src/config/data.js
+++ b/src/config/data.js
@@ -25,7 +25,7 @@ export const feeds = [
   },
   {
     "id": "114",
-    "title": "The Saints just scored a touchdown.",
+    "title": "The Saints score a touchdown.",
     "organization": "Saints",
     "color": "#40403F",
     "status": "On",


### PR DESCRIPTION
This pull request resolves #12.

I changed the component used to render the applet preview from the hard-to-customize React Native Elements Card component to a custom designed View component. This decision allowed me much more freedom in my design decisions to closely mimic the mockups. Below is a screenshot of the current applet feed UI with rendered applet previews.  

<img width="337" alt="screen shot 2017-11-22 at 6 14 26 pm" src="https://user-images.githubusercontent.com/9016615/33131751-1f5bae08-cfb1-11e7-9168-e175127195a6.png">
